### PR TITLE
Fix typo in init structure prompt

### DIFF
--- a/madina_shop_full/prompts/05_init_structure.txt
+++ b/madina_shop_full/prompts/05_init_structure.txt
@@ -1,2 +1,2 @@
-Étape 5: Initialise la structure de dossier src/ et public/ comme dans le template.
+Étape 5: Initialise la structure des dossiers src/ et public/ comme dans le template.
 Crée tous les sous-dossiers (assets, components, pages, services, styles, utils).


### PR DESCRIPTION
## Summary
- fix French wording for initialization instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68405d78f05c8329b84e3cf7f0cef2c9