### PR TITLE
Fix openapi schema closure

### DIFF
--- a/madina_shop_full/services/logistics-service/docs/openapi.yaml
+++ b/madina_shop_full/services/logistics-service/docs/openapi.yaml
@@ -60,3 +60,7 @@ components:
           type: string
         payerId:
           type: string
+      required:
+        - quoteId
+        - payerId
+


### PR DESCRIPTION
## Summary
- complete missing closing lines in logistics-service OpenAPI specification

## Testing
- `python3 - <<'EOF'`
  (fails: No module named 'yaml')

------
https://chatgpt.com/codex/tasks/task_e_6840608390688329ba40f78e87c37239