### PR TITLE
Add productService unit test skeleton

### DIFF
--- a/tests/unit/productService.test.ts
+++ b/tests/unit/productService.test.ts
@@ -1,0 +1,38 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+jest.mock('@supabase/supabase-js');
+
+// Require the service after mocking createClient
+const productService = require('../../apps/shop/src/services/productService');
+
+const mockFrom = jest.fn();
+const mockSelect = jest.fn();
+
+(createClient as jest.Mock).mockReturnValue({
+  from: mockFrom,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('productService', () => {
+  test('getProducts returns array from Supabase', async () => {
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect.mockResolvedValueOnce({ data: [{ id: 1 }], error: null }),
+    });
+
+    const result = await productService.getProducts();
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toEqual([{ id: 1 }]);
+  });
+
+  test('getProductById returns null when no rows', async () => {
+    mockFrom.mockReturnValueOnce({
+      select: mockSelect.mockResolvedValueOnce({ data: [], error: null }),
+    });
+
+    const result = await productService.getProductById(999);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest unit tests for productService

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6840775720788329bd8075e0ca589b64