### PR TITLE
Update CI Node caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 18
           cache: npm
+          cache-dependency-path: madina_shop_full/apps/shop/package-lock.json
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- specify path to package-lock.json for Node caching

## Testing
- `npm test --prefix madina_shop_full/apps/shop` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422cd7fe488329b2239cd6621fa01a