### PR TITLE
Remove npm cache options

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: npm
-          cache-dependency-path: madina_shop_full/apps/shop/package-lock.json
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- remove `cache` settings from Node.js setup step in CI workflow

## Testing
- `npm ci` *(fails: EUSAGE - requires package-lock.json)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68423321bcb8832985bb5ad296e4a1c4